### PR TITLE
Fixed rounding issue with Float comparison

### DIFF
--- a/Source/Sitecore.ContentSearch.Spatial/Indexing/LuceneDocumentBuilder.cs
+++ b/Source/Sitecore.ContentSearch.Spatial/Indexing/LuceneDocumentBuilder.cs
@@ -78,17 +78,19 @@ namespace Sitecore.ContentSearch.Spatial.Indexing
             
             double lng = 0;
             double lat = 0;
+            bool parsedLat = false;
+            bool parsedLong = false;
+
             if (!string.IsNullOrEmpty(item[setting.LatitudeField]))
             {
-                Double.TryParse(item[setting.LatitudeField], out lat);
+                parsedLat = Double.TryParse(item[setting.LatitudeField], out lat);
             }
 
             if (!string.IsNullOrEmpty(item[setting.LongitudeField]))
             {
-                Double.TryParse(item[setting.LongitudeField], out lng);
+                parsedLong = Double.TryParse(item[setting.LongitudeField], out lng);
             }
-
-            if (lng == 0 || lat == 0)
+            if (!parsedLat && !parsedLong)
                 return pointFields;
 
             pointFields = AddPoint( lng, lat);


### PR DESCRIPTION
When previously checking the Latitude it would not index any items that were between 0.4 and -0.4 on either plane because it would they would be rounded down and compared to Int 0.  With the condition being OR it would throw it away even though it was valid GPS coordinate, such as London...
